### PR TITLE
change attachTemplate to collapse by default

### DIFF
--- a/src/modules/common.mts
+++ b/src/modules/common.mts
@@ -61,7 +61,7 @@ export class QAppPrefs
 		showFirstChars     : 3,
 		messageAttachTop   : true,
 		messageAttachBottom: false,
-		attachTemplate     : '<div class="qnote-title">QNote: {{ qnote_date }}</div>\n<div class="qnote-text">{{ qnote_text }}</div>',
+		attachTemplate     : '<details><summary class="qnote-title">QNote: {{ qnote_date }}</summary>\n<div class="qnote-text">{{ qnote_text }}</div>\n</details>',
 		treatTextAsHtml    : false,
 		enableDebug        : true,
 	}


### PR DESCRIPTION
Hi,

I've added a details element to the template so that it collapses the note when shown attached to the message, and I thought it might be usefull for other people as well.

No javascript, no CSS: just plain HTML :-D